### PR TITLE
Force Chromium to ignore GPU blacklist

### DIFF
--- a/index.js
+++ b/index.js
@@ -105,6 +105,7 @@ process.env.NODE_TLS_REJECT_UNAUTHORIZED = '0'
 
 server.get('*', Util.processRequest)
 
+electronApp.commandLine.appendSwitch('ignore-gpu-blacklist')
 electronApp.commandLine.appendSwitch('ignore-certificate-errors')
 electronApp.commandLine.appendSwitch(
   'autoplay-policy',


### PR DESCRIPTION
這是在我Linux Mint 17上使用內顯Intel HD4600(Mesa 10.1.3)時發現的情況。

因為原本使用Chrom或Firefox開啟網頁版都能正常開啟，但是一使用雀魂Plus便一直跳出 'Laya3D init error must support webGl' 的錯誤訊息

調查了一下也發現了類似如此的情形：
https://github.com/electron/electron/issues/8217

根據建議加上 'ignore-gpu-blacklist' 之後就能夠正常運作了，不過由於強制繞過黑名單的關係，可能也會使部分真的不支援WebGL型號的GPU意外開啟。

--------

The Chromium Electron using now may blacklisted some GPU,
which can normally run WebGL in current version of Chrome/Chromium.

Using '--ignore-gpu-blacklist' is one solution, although it may
let some GPU that really not being able to run WebGL
accidentally bypass the limitation.